### PR TITLE
api: Add method to add logon keys

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,6 +2,27 @@ extern crate bitflags;
 
 use super::ffi::*;
 
+/// Special key types
+pub enum KeyType {
+    /// Keys which can be created, updated and read from userspace
+    /// but are not intended for use by the kernel.
+    User,
+    /// Keys which can only be created and updated from
+    /// userspace but not read back. They are intended to be
+    /// only accessible from kernel space.
+    Logon,
+}
+
+impl KeyType {
+    /// Retrieve the constant value for the key type
+    pub fn value(self) -> &'static str {
+        match self {
+            KeyType::User => KEY_TYPE_USER,
+            KeyType::Logon => KEY_TYPE_LOGON,
+        }
+    }
+}
+
 /// Special keyrings predefined for a process.
 pub enum SpecialKeyring {
     /// A thread-specific keyring.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -6,6 +6,9 @@ extern crate libc;
 #[allow(non_camel_case_types)]
 pub type key_serial_t = libc::int32_t;
 
+pub const KEY_TYPE_USER:                    &'static str = "user";
+pub const KEY_TYPE_LOGON:                   &'static str = "logon";
+
 pub const KEY_SPEC_THREAD_KEYRING:          key_serial_t = -1;
 pub const KEY_SPEC_PROCESS_KEYRING:         key_serial_t = -2;
 pub const KEY_SPEC_SESSION_KEYRING:         key_serial_t = -3;


### PR DESCRIPTION
The keyring has a "logon" key type for keys that userspace can create and update but not read. This method allows to add such keys.