### PR TITLE
Cleanup, fix warnings, move to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,22 +3,21 @@ name = "keyutils"
 version = "0.4.0"
 authors = ["Ben Boeckel <mathstuf@gmail.com>"]
 license = "BSD-3-Clause"
-description = """
-Rust interface to the Linux keyring.
-"""
+description = "Rust interface to the Linux keyring."
 repository = "https://github.com/mathstuf/rust-keyutils.git"
-homepage = "https://github.com/mathstuf/rust-keyutils.git"
-documentation = "https://docs.rs/keyutils/~0.4"
+homepage = "https://github.com/mathstuf/rust-keyutils"
+documentation = "https://docs.rs/keyutils"
 readme = "README.md"
+edition = "2018"
 
 [workspace]
 members = ["libkeyutils-sys"]
 
 [dependencies]
-bitflags = "^1.0"
-errno = "~0.2"
-itertools = "~0.8"
-libkeyutils-sys = { path = "libkeyutils-sys", version = "~0.3.1" }
-log = "~0.4"
+bitflags = "1.0"
+errno = "0.2"
+itertools = "0.8"
+libkeyutils-sys = { path = "libkeyutils-sys" }
+log = "0.4"
 
-libc = "~0.2"
+libc = "0.2"

--- a/libkeyutils-sys/Cargo.toml
+++ b/libkeyutils-sys/Cargo.toml
@@ -3,14 +3,12 @@ name = "libkeyutils-sys"
 version = "0.3.1"
 authors = ["Ben Boeckel <mathstuf@gmail.com>"]
 license = "BSD-3-Clause"
-description = """
-FFI bindings to libkeyutils.
-"""
+description = "FFI bindings to libkeyutils."
 repository = "https://github.com/mathstuf/rust-keyutils.git"
-homepage = "https://github.com/mathstuf/rust-keyutils.git"
-documentation = "https://docs.rs/libkeyutils-sys/~0.3"
+homepage = "https://github.com/mathstuf/rust-keyutils"
 keywords = ["keyutils"]
 links = "keyutils"
+edition = "2018"
 
 [dependencies]
-libc = "~0.2"
+libc = "0.2"

--- a/libkeyutils-sys/src/constants.rs
+++ b/libkeyutils-sys/src/constants.rs
@@ -27,7 +27,7 @@
 // Ignore rustfmt changes in here. The horizontal alignment is too useful to give up.
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
-use types::{key_perm_t, key_serial_t};
+use crate::types::{key_perm_t, key_serial_t};
 
 pub const KEY_TYPE_USER:                    &str = "user";
 pub const KEY_TYPE_LOGON:                   &str = "logon";

--- a/libkeyutils-sys/src/functions.rs
+++ b/libkeyutils-sys/src/functions.rs
@@ -24,9 +24,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crates::libc;
-
-use types::{key_perm_t, key_serial_t};
+use crate::types::{key_perm_t, key_serial_t};
 
 #[rustfmt::skip]
 extern "C" {

--- a/libkeyutils-sys/src/lib.rs
+++ b/libkeyutils-sys/src/lib.rs
@@ -37,10 +37,6 @@
 //!   - `keyctl(3)`
 //!   - `keyctl(7)`
 
-mod crates {
-    pub extern crate libc;
-}
-
 mod constants;
 mod functions;
 mod types;

--- a/libkeyutils-sys/src/types.rs
+++ b/libkeyutils-sys/src/types.rs
@@ -26,7 +26,5 @@
 
 #![allow(non_camel_case_types)]
 
-use crates::libc;
-
-pub type key_serial_t = libc::int32_t;
-pub type key_perm_t = libc::uint32_t;
+pub type key_serial_t = i32;
+pub type key_perm_t = u32;

--- a/src/api.rs
+++ b/src/api.rs
@@ -32,13 +32,12 @@ use std::result;
 use std::str;
 use std::time::Duration;
 
-use crates::errno;
-use crates::libc;
-use crates::libkeyutils_sys::*;
+use libkeyutils_sys::*;
+use log::error;
 
-use constants::{DefaultKeyring, KeyPermissions, KeyringSerial, Permission, SpecialKeyring};
-use keytype::*;
-use keytypes;
+use crate::constants::{DefaultKeyring, KeyPermissions, KeyringSerial, Permission, SpecialKeyring};
+use crate::keytype::*;
+use crate::keytypes;
 
 /// Reexport of `Errno` as `Error`.
 pub type Error = errno::Errno;
@@ -806,14 +805,8 @@ impl KeyManager {
 #[cfg(test)]
 mod tests {
     use std::thread;
-    use std::time::Duration;
 
-    use crates::libc;
-
-    use api::Keyring;
-    use constants::{Permission, SpecialKeyring};
-    use keytype::KeyType;
-    use keytypes;
+    use super::*;
 
     #[test]
     fn test_add_key() {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -24,7 +24,8 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crates::libkeyutils_sys::*;
+use bitflags::bitflags;
+use libkeyutils_sys::*;
 
 /// Special keyrings predefined for a process.
 pub enum SpecialKeyring {

--- a/src/keytypes/asymmetric.rs
+++ b/src/keytypes/asymmetric.rs
@@ -26,7 +26,7 @@
 
 //! Asymmetric keys
 
-use keytype::*;
+use crate::keytype::*;
 
 /// Asymmetric keys support encrypting, decrypting, signing, and verifying data.
 ///

--- a/src/keytypes/big_key.rs
+++ b/src/keytypes/big_key.rs
@@ -26,7 +26,7 @@
 
 //! Big keys
 
-use keytype::*;
+use crate::keytype::*;
 
 /// Big keys.
 ///

--- a/src/keytypes/blacklist.rs
+++ b/src/keytypes/blacklist.rs
@@ -28,8 +28,8 @@
 
 use std::borrow::Cow;
 
-use keytype::*;
-use keytypes::AsciiHex;
+use super::AsciiHex;
+use crate::keytype::*;
 
 /// Blacklist hashes.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/src/keytypes/dns_resolver.rs
+++ b/src/keytypes/dns_resolver.rs
@@ -28,7 +28,7 @@
 
 use std::borrow::Cow;
 
-use keytype::*;
+use crate::keytype::*;
 
 /// A DNS resolver key.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/src/keytypes/encrypted.rs
+++ b/src/keytypes/encrypted.rs
@@ -28,8 +28,8 @@
 
 use std::borrow::Cow;
 
-use keytype::*;
-use keytypes::AsciiHex;
+use super::AsciiHex;
+use crate::keytype::*;
 
 /// Encrypted keys.
 ///

--- a/src/keytypes/keyring.rs
+++ b/src/keytypes/keyring.rs
@@ -26,7 +26,7 @@
 
 //! Keyrings
 
-use keytype::*;
+use crate::keytype::*;
 
 /// Keyrings contain other keys.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/src/keytypes/logon.rs
+++ b/src/keytypes/logon.rs
@@ -30,9 +30,9 @@
 
 use std::borrow::Cow;
 
-use crates::libkeyutils_sys::KEY_TYPE_LOGON;
+use libkeyutils_sys::KEY_TYPE_LOGON;
 
-use keytype::*;
+use crate::keytype::*;
 
 /// Keys which can only be created and updated from userspace but not read back.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/src/keytypes/mod.rs
+++ b/src/keytypes/mod.rs
@@ -90,7 +90,7 @@ impl AsciiHex {
 
 #[cfg(test)]
 mod tests {
-    use keytypes::AsciiHex;
+    use super::*;
 
     fn check(input: &[u8], expected: &str) {
         assert_eq!(AsciiHex::convert(input), expected);

--- a/src/keytypes/rxrpc.rs
+++ b/src/keytypes/rxrpc.rs
@@ -28,7 +28,7 @@
 
 use std::borrow::Cow;
 
-use keytype::*;
+use crate::keytype::*;
 
 /// An RxRPC client key.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/src/keytypes/rxrpc_s.rs
+++ b/src/keytypes/rxrpc_s.rs
@@ -28,7 +28,7 @@
 
 use std::borrow::Cow;
 
-use keytype::*;
+use crate::keytype::*;
 
 /// An RxRPC server key.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/src/keytypes/trusted.rs
+++ b/src/keytypes/trusted.rs
@@ -28,10 +28,10 @@
 
 use std::borrow::Cow;
 
-use crates::itertools::Itertools;
+use itertools::Itertools;
 
-use keytype::*;
-use keytypes::AsciiHex;
+use super::AsciiHex;
+use crate::keytype::*;
 
 /// Trusted keys are rooted in the TPM.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/src/keytypes/user.rs
+++ b/src/keytypes/user.rs
@@ -26,9 +26,9 @@
 
 //! User keys
 
-use crates::libkeyutils_sys::KEY_TYPE_USER;
+use libkeyutils_sys::KEY_TYPE_USER;
 
-use keytype::*;
+use crate::keytype::*;
 
 /// Keys which can be created, updated, and read from userspace but are not intended for use by the
 /// kernel.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,26 +30,9 @@
 
 #![warn(missing_docs)]
 
-#[macro_use]
-extern crate bitflags;
-
-#[macro_use]
-extern crate log;
-
-mod crates {
-    // public
-    pub extern crate libc;
-
-    // private
-    pub extern crate errno;
-    pub extern crate itertools;
-    pub extern crate libkeyutils_sys;
-}
-
+mod api;
 mod constants;
 mod keytype;
-
-mod api;
 
 pub mod keytypes;
 


### PR DESCRIPTION
This change does the following to get `keyutils` building without warnings on Rust 2018 edition.
  - Adds `edition = "2018"` to both `Cargo.toml`s
  - Cleans up `Cargo.toml` to:
    - Just use default versioning where they are equivalent to existing `~` and `^` patterns.
    - Have the documentation/homepage point the the correct thing.
  - Fixup `use` statements to use `crate` or `super` where approprtiate.
  - Use `u32` and `i32` instead of the `libc` types (as those are deprecated).
  - Remove unnecessary `use` statements.