### PR TITLE
Improve various CI components

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,12 @@ clippy_task:
     container:
         image: rust:latest
     component_script: rustup component add clippy
+    lockfile_script: cargo generate-lockfile
+    cargo_cache:
+        folder: $CARGO_HOME/registry
+        fingerprint_script: cat Cargo.lock
     clippy_script: cargo clippy
+    before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 rustfmt_task:
     container:
@@ -21,9 +26,21 @@ linux_task:
       container:
         image: rustlang/rust:nightly
     keyutils_script: apt-get update && apt-get install libkeyutils-dev
+    lockfile_script: cargo generate-lockfile
     cargo_cache:
         folder: $CARGO_HOME/registry
         fingerprint_script: cat Cargo.lock
     build_script: cargo build
     test_script: cargo test
+    before_cache_script: rm -rf $CARGO_HOME/registry/index
+
+minimal_version_task:
+    # We make sure we can build with the minimum specificed versions
+    container:
+        image: rustlang/rust:nightly
+    lockfile_script: cargo generate-lockfile -Z minimal-versions
+    cargo_cache:
+        folder: $CARGO_HOME/registry
+        fingerprint_script: cat Cargo.lock
+    build_script: cargo build
     before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,43 +1,29 @@
 clippy_task:
     container:
         image: rust:latest
-    keyutils_script: apt-get update && apt-get install libkeyutils-dev
     component_script: rustup component add clippy
-    fmt_script: cargo clippy
-    toolchain_cache:
-        folder: $RUSTUP_HOME
-        fingerprint_script: rustc --version
-    cargo_cache:
-        folder: $CARGO_HOME/registry
-        fingerprint_script: cat Cargo.lock
+    clippy_script: cargo clippy
 
 rustfmt_task:
     container:
+        # Our .rustfmt.toml uses currently unstable features
         image: rustlang/rust:nightly
-    keyutils_script: apt-get update && apt-get install libkeyutils-dev
     component_script: rustup component add rustfmt
     fmt_script: cargo fmt --all -- --check
 
 linux_task:
-    container:
-      image: rust:latest
     matrix:
-        - env:
-              RUSTVER: 1.32.0
-        - env:
-              RUSTVER: stable
-        - allow_failures: true
-          env:
-              RUSTVER: nightly
+    - container:
+        image: rust:1.32.0
+    - container:
+        image: rust:latest
+    - allow_failures: true
+      container:
+        image: rustlang/rust:nightly
     keyutils_script: apt-get update && apt-get install libkeyutils-dev
-    rustup_script: rustup toolchain install $RUSTVER
-    toolchain_cache:
-        folder: $RUSTUP_HOME
-        fingerprint_script: rustc +$RUSTVER --version
-    update_script: cargo +$RUSTVER update
     cargo_cache:
         folder: $CARGO_HOME/registry
         fingerprint_script: cat Cargo.lock
-    build_script: cargo +$RUSTVER build
-    test_script: cargo +$RUSTVER test
+    build_script: cargo build
+    test_script: cargo test
     before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,16 +1,15 @@
 clippy_task:
     container:
-        image: rustlang/rust:nightly
+        image: rust:latest
     keyutils_script: apt-get update && apt-get install libkeyutils-dev
     component_script: rustup component add clippy
-    update_script: cargo +nightly update
+    fmt_script: cargo clippy
     toolchain_cache:
         folder: $RUSTUP_HOME
-        fingerprint_script: rustc +nightly --version
+        fingerprint_script: rustc --version
     cargo_cache:
         folder: $CARGO_HOME/registry
         fingerprint_script: cat Cargo.lock
-    fmt_script: cargo +nightly clippy
 
 rustfmt_task:
     container:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ edition = "2018"
 members = ["libkeyutils-sys"]
 
 [dependencies]
-bitflags = "1.0"
+bitflags = "1.0.4"
 errno = "0.2"
 itertools = "0.8"
 libkeyutils-sys = { path = "libkeyutils-sys" }
-log = "0.4"
+log = "0.4.4"
 
 libc = "0.2"


### PR DESCRIPTION
Depends on #27 for test fixes

This pull request does the following:
  - Uses the proper images so that toolchains don't have to be redownloaded on each build.
  - Caches cargo registry for all steps except `rustfmt`
  - We run clippy on stable, which fixes #25 
  - We keep running rustfmt on nightly for now, as the  `.rustfmt.toml` uses [unstable features](https://github.com/rust-lang/rustfmt/blob/master/Configurations.md).
  - We keep `allow_failures` to `true` on the nightly test, note that this will still make the PR turn Red, even if it doesn't fail the entire build
  - Adds a build stage to make sure the minimal specified versions work. As a consequence, some versions in the `Cargo.toml` had to be increased:
    - `bitflags` to `1.0.4` because we need: https://github.com/bitflags/bitflags/pull/165
    - `log` to `0.4.4` because we need: https://github.com/rust-lang-nursery/log/pull/288
  - Adds some comments explaining how the build stages work 

The CI is now faster, simpler, and more reliable.