### PR TITLE
build: add static feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2018"
 [workspace]
 members = ["keyutils-raw"]
 
+[features]
+static = ["keyutils-raw/static"]
+
 [dev-dependencies]
 lazy_static = "1"
 regex = "1"

--- a/keyutils-raw/Cargo.toml
+++ b/keyutils-raw/Cargo.toml
@@ -10,5 +10,8 @@ keywords = ["keyutils"]
 links = "keyutils"
 edition = "2018"
 
+[features]
+static = []
+
 [dependencies]
 libc = "0.2"

--- a/keyutils-raw/build.rs
+++ b/keyutils-raw/build.rs
@@ -25,5 +25,9 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 fn main() {
-    println!("cargo:rustc-link-lib=keyutils");
+    if cfg!(feature = "static") {
+        println!("cargo:rustc-link-lib=static=keyutils");
+    } else {
+        println!("cargo:rustc-link-lib=keyutils");
+    }
 }


### PR DESCRIPTION
Add a `static` feature that forces static linking for keyutils. I recognize this is a bit of a niche request, comments and feedback are welcome.