### PR TITLE
cirrus-ci: rotate the CODECOV_TOKEN value

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,7 +49,7 @@ coverage_task:
     container:
         image: rust:latest
     environment:
-        CODECOV_TOKEN: ENCRYPTED[1e221ef78a37c960613ff80db7141f3158e3218031934395466f4720f450b7acfd74e587819435ce9be0b13fa1b68f1b]
+        CODECOV_TOKEN: ENCRYPTED[0064853784b30e0b6f74648c237de43e2ef8d37e7146b2fc1b53872feef0519e5b2e9a0862056e400e528e7fdafa0b55]
     tarpaulin_cache:
         folder: .ci
         populate_script: .ci/tarpaulin.sh

--- a/src/keytypes/rxrpc.rs
+++ b/src/keytypes/rxrpc.rs
@@ -67,7 +67,7 @@ impl KeyPayload for Payload {
         //     uint8_t     ticket[0];      /* the encrypted ticket */
         // };
 
-        payload.extend((2 as u16).to_ne_bytes().iter());
+        payload.extend(2_u16.to_ne_bytes().iter());
         payload.extend((self.ticket.len() as u16).to_ne_bytes().iter());
         payload.extend(self.expiry.to_ne_bytes().iter());
         payload.extend(self.version.to_ne_bytes().iter());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
 //! This crate provides a high-level API for interacting with the Linux keys subsystem.
 
 #![warn(missing_docs)]
+#![allow(clippy::upper_case_acronyms)]
 
 mod api;
 mod constants;


### PR DESCRIPTION
See the security release announcement here:

     https://about.codecov.io/security-update/

However, this URL is not indicative of *what* the security problem was
and archive.org apparently has issues saving the page. So in the
interest of history spelunkers, the relevant bit is reproduced here for
posterity:

     Codecov takes the security of its systems and data very seriously
     and we have implemented numerous safeguards to protect you. On
     Thursday, April 1, 2021, we learned that someone had gained
     unauthorized access to our Bash Uploader script and modified it
     without our permission. The actor gained access because of an error
     in Codecov’s Docker image creation process that allowed the actor
     to extract the credential required to modify our Bash Uploader
     script.