### PR TITLE
Remove unused itertools dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ semver = "*"
 [dependencies]
 bitflags = "1.0.4"
 errno = "0.2"
-itertools = "0.9"
 keyutils-raw = { path = "keyutils-raw" }
 log = "0.4.4"
 uninit = "0.3"


### PR DESCRIPTION
I was not able to see where this was used, and running `cargo build` worked correctly.