### PR TITLE
Update errno to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ semver = "*"
 
 [dependencies]
 bitflags = "1.0.4"
-errno = "0.2"
+errno = "0.3"
 keyutils-raw = { path = "keyutils-raw" }
 log = "0.4.4"
 uninit = "0.3"

--- a/keyutils-raw/Cargo.toml
+++ b/keyutils-raw/Cargo.toml
@@ -12,6 +12,6 @@ edition = "2018"
 [dependencies]
 log = "0.4.4"
 
-errno = "0.2"
+errno = "0.3"
 libc = "0.2"
 uninit = "0.3"


### PR DESCRIPTION
This PR updates `errno` to the latest version, matching what other crates in the ecosystem use.

While technically the MSRV [was raised](https://github.com/lambda-fairy/rust-errno/blob/main/CHANGELOG.md) to 1.48, I believe the crate should build on Linux with much older compilers to match `keyutils` current MSRV. The only thing, AFAICT, using 1.48 is `windows-sys` which won't compile on a Linux target anyway.